### PR TITLE
Update README.md

### DIFF
--- a/docs/helpful-repositories/README.md
+++ b/docs/helpful-repositories/README.md
@@ -3,4 +3,6 @@ Helpful Repositories
 
 * [Trail of Bits](https://github.com/trailofbits)
 
-* [Consensys](https://github.com/ConsenSys)
+* [Consensys Smart Contract Best Practices](https://github.com/ConsenSys/smart-contract-best-practices)
+
+* [SmartContractSecurity](https://github.com/SmartContractSecurity/SWC-registry)


### PR DESCRIPTION
The ConsenSys org on github is not curated for security, so it makes much more sense to point directly atThe Best Practices. 
The Smart Contract Security SWC repo also feels like a good fit.